### PR TITLE
[fix] Component: fix return types of ComponentFn

### DIFF
--- a/@reface/__tests__/component.test.tsx
+++ b/@reface/__tests__/component.test.tsx
@@ -1,4 +1,5 @@
-import { component } from "@reface";
+import { i } from "@reface/elements";
+import { component, html } from "@reface";
 import { TestUtils } from "./testUtils.ts";
 
 interface ButtonProps {
@@ -36,6 +37,20 @@ Deno.test("component - template literal usage", () => {
   );
 });
 
+Deno.test("component - html string usage", () => {
+  const utils = new TestUtils();
+  const Button = component<ButtonProps>((props, children) => (
+    html`<button class="${`btn btn-${props.color || "default"}`}">
+      ${children}
+    </button>`
+  ));
+
+  utils.assertRender(
+    Button({ color: "primary" })`Click me`,
+    '<button class="btn btn-primary"> Click me </button>',
+  );
+});
+
 Deno.test("component - without children", () => {
   const utils = new TestUtils();
   const Icon = component<{ name: string }>((props) => (
@@ -47,5 +62,62 @@ Deno.test("component - without children", () => {
   utils.assertRender(
     template,
     '<i class="icon-home"></i>',
+  );
+});
+
+Deno.test("component - required attribute variants", () => {
+  const utils = new TestUtils();
+
+  interface IconProps {
+    name: string;
+    size?: string;
+  }
+
+  // JSX вариант
+  const IconJSX = component<IconProps>((props) => (
+    <i
+      class={`icon-${props.name}`}
+      style={props.size ? `font-size: ${props.size}` : ""}
+    />
+  ));
+
+  // HTML string вариант
+  const IconHtml = component<IconProps>((props) => (
+    html`<i class="icon-${props.name}" style="${
+      props.size ? `font-size: ${props.size}` : ""
+    }"></i>`
+  ));
+
+  // Element template вариант
+  const IconElement = component<IconProps>((props) => (
+    i({
+      class: `icon-${props.name}`,
+      style: props.size ? `font-size: ${props.size}` : "",
+    })
+  ));
+
+  // @ts-expect-error TEST
+  IconJSX({});
+  // @ts-expect-error TEST
+  IconHtml({});
+  // @ts-expect-error TEST
+  IconElement({});
+
+  // Проверка рендеринга для всех вариантов
+  const expected = '<i class="icon-home" style="font-size: 24px"></i>';
+
+  utils.assertRender(
+    IconJSX({ name: "home", size: "24px" })``,
+    expected,
+  );
+
+  utils.assertRender(
+    IconHtml({ name: "home", size: "24px" })``,
+    expected,
+  );
+
+  utils.assertRender(
+    IconElement({ name: "home", size: "24px" })``,
+    expected,
   );
 });

--- a/@reface/component.ts
+++ b/@reface/component.ts
@@ -12,7 +12,7 @@ export const component = <
   P extends Record<string, any>,
   T extends TemplatePayload = TemplatePayload,
 >(
-  render: ComponentFn<P, T>,
+  render: ComponentFn<P>,
 ): Template<P, T> => {
   const componentTemplate = createTemplateFactory({
     type: "component",

--- a/@reface/elements.ts
+++ b/@reface/elements.ts
@@ -161,6 +161,9 @@ export const a: Template<HTML.HTMLAnchorAttributes, Record<string, any>> =
 export const code: Template<HTML.HTMLAttributes, Record<string, any>> =
   createElementTemplate({ tag: "code" });
 
+export const i: Template<HTML.HTMLAttributes, Record<string, any>> =
+  createElementTemplate({ tag: "i" });
+
 export const em: Template<HTML.HTMLAttributes, Record<string, any>> =
   createElementTemplate({ tag: "em" });
 

--- a/@reface/jsx/createElement.ts
+++ b/@reface/jsx/createElement.ts
@@ -6,11 +6,16 @@ import {
   isTemplate,
   type Template,
   type TemplateAttributes,
+  TemplateHtmlAttributes,
+  TemplateMethods,
   type TemplatePayload,
 } from "@reface/template";
 import { createTemplateFactory } from "../template/createTemplateFactory.ts";
 
-const jsxTemplate = createTemplateFactory({
+const jsxTemplate = createTemplateFactory<
+  TemplateHtmlAttributes,
+  TemplatePayload
+>({
   type: "jsx",
   create: {
     defaults: {
@@ -20,29 +25,23 @@ const jsxTemplate = createTemplateFactory({
 });
 
 export function createElement<
-  P extends BaseAttributes,
+  P extends TemplateHtmlAttributes,
   T extends TemplatePayload = TemplatePayload,
 >(
-  type: string | ComponentFn<P, T> | Template<P, T>,
+  type: string | ComponentFn<P> | Template<P, T>,
   props: P | null,
   ...children: ElementChildType[]
-): Template<BaseAttributes, TemplatePayload> {
-  if (isTemplate(type)) {
-    return (type((props ?? {}) as P)`${children}`) as unknown as Template<
-      BaseAttributes,
-      TemplatePayload
-    >;
+): Template<P, T> {
+  if (isTemplate<P, T, any>(type)) {
+    return (type((props ?? {}) as P)`${children}`);
   }
-  if (isComponentFn<P, T>(type)) {
-    return (type((props ?? {}) as P, children)) as unknown as Template<
-      BaseAttributes,
-      TemplatePayload
-    >;
+  if (isComponentFn<P>(type)) {
+    return (type((props ?? {}) as P, children));
   }
 
   return jsxTemplate({
     tag: type,
     attributes: props ?? {},
     children,
-  });
+  }) as unknown as Template<P, T>; // FIXME: find a way to remove unknown
 }

--- a/@reface/jsx/jsx-runtime.ts
+++ b/@reface/jsx/jsx-runtime.ts
@@ -12,7 +12,7 @@ type JsxFn = <
   P extends BaseAttributes,
   T extends TemplatePayload = TemplatePayload,
 >(
-  tag: string | ComponentFn<P, T> | Template<P, T>,
+  tag: string | ComponentFn<P> | Template<P, T>,
   props: P | null,
   _key?: string,
 ) => Template<P, T>;
@@ -21,7 +21,7 @@ export const jsx: JsxFn = function <
   P extends BaseAttributes,
   T extends TemplatePayload,
 >(
-  tag: string | ComponentFn<P, T> | Template<P, T>,
+  tag: string | ComponentFn<P> | Template<P, T>,
   props: P | null,
   _key?: string,
 ): Template<P, T> {

--- a/@reface/template/createTemplateFactory.ts
+++ b/@reface/template/createTemplateFactory.ts
@@ -24,11 +24,11 @@ export const createTemplateFactory = <
 ): TemplateFactory<A, P, M> => {
   const factory: TemplateFactory<A, P, M> = ((
     templateFactoryConfig:
-      | ComponentFn<A, P>
+      | ComponentFn<A>
       | BaseTemplateConfig<P>
       | HTMLTemplateConfig<A, P>,
   ) => {
-    if (isComponentFn<A, P>(templateFactoryConfig)) {
+    if (isComponentFn<A>(templateFactoryConfig)) {
       const rawTemplate: RawTemplate<NormalizeAttributes<A>, P> = {
         type: createTemplateFactoryConfig.type,
         attributes: {} as NormalizeAttributes<A>,

--- a/@reface/template/createTemplateProxy.ts
+++ b/@reface/template/createTemplateProxy.ts
@@ -49,7 +49,7 @@ export function createTemplateProxy<
   rawTemplate: RawTemplate<NormalizeAttributes<A>, P>;
   createTemplateFactoryConfig: TemplateFactoryConfig<A, P, M>;
   templateFactoryConfig:
-    | ComponentFn<A, P>
+    | ComponentFn<A>
     | BaseTemplateConfig<P>
     | HTMLTemplateConfig<A, P>;
 }): Template<A, P, M> {

--- a/@reface/template/types.ts
+++ b/@reface/template/types.ts
@@ -29,11 +29,10 @@ export type ElementChildType = Arrayable<PrimitiveChild | ComplexChild>;
 
 export type ComponentFn<
   A extends TemplateAttributes = TemplateAttributes,
-  P extends TemplatePayload = TemplatePayload,
 > = (
   attrs: A,
   children: ElementChildType[],
-) => Template<A, P>;
+) => Template<any, any, any>;
 
 export type RawTemplateAttributes = {
   [key: string]: any;
@@ -132,7 +131,7 @@ export type TemplateFactory<
   ): Template<A & TemplateHtmlAttributes, P, M>;
 
   <CA extends BaseAttributes>(
-    component: ComponentFn<CA, P>,
+    component: ComponentFn<CA>,
   ): Template<CA, P, TemplateMethods<CA, P>>;
 };
 

--- a/@reface/template/utils.ts
+++ b/@reface/template/utils.ts
@@ -5,6 +5,7 @@ import type {
   RawTemplate,
   Template,
   TemplateAttributes,
+  TemplateMethods,
   TemplatePayload,
 } from "./types.ts";
 import { HTML_ENTITIES, REFACE_TEMPLATE } from "./constants.ts";
@@ -24,12 +25,15 @@ export function isHTMLTemplateConfig<
 
 export function isComponentFn<
   A extends TemplateAttributes,
-  P extends TemplatePayload,
->(input: any): input is ComponentFn<A, P> {
+>(input: any): input is ComponentFn<A> {
   return typeof input === "function";
 }
 
-export function isTemplate(value: unknown): value is Template {
+export function isTemplate<
+  A extends TemplateAttributes,
+  P extends TemplatePayload,
+  M extends TemplateMethods<A, P>,
+>(value: unknown): value is Template<A, P, M> {
   return typeof value === "function" &&
     (value as any)[REFACE_TEMPLATE] === true;
 }


### PR DESCRIPTION
Fix component return type in ComponentFn when return Template

![image](https://github.com/user-attachments/assets/909d1243-00b2-4e20-83ae-99d454473fe4)


also: add element `<i>`